### PR TITLE
[SDK-4821] Refactored FeedTableViewController Demo

### DIFF
--- a/JWBestPracticeApps/FeedTableViewController/FeedItemCell.swift
+++ b/JWBestPracticeApps/FeedTableViewController/FeedItemCell.swift
@@ -15,6 +15,25 @@ class FeedItemCell: UITableViewCell {
     
     @IBOutlet weak var containerView: UIView!
     
+    var player: JWPlayerController? {
+        didSet {
+            guard let playerView = player?.view else {
+                return
+            }
+            
+            containerView.addSubview(playerView)
+            playerView.constraintToSuperview()
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        for view in containerView.subviews {
+            view.removeFromSuperview()
+        }
+    }
+    
     override var reuseIdentifier: String? {
         return FeedItemCellIdentifier
     }

--- a/JWBestPracticeApps/FeedTableViewController/FeedItemCell.swift
+++ b/JWBestPracticeApps/FeedTableViewController/FeedItemCell.swift
@@ -16,6 +16,10 @@ class FeedItemCell: UITableViewCell {
     @IBOutlet weak var containerView: UIView!
     
     var player: JWPlayerController? {
+        willSet {
+            player?.view?.removeFromSuperview()
+        }
+        
         didSet {
             guard let playerView = player?.view else {
                 return
@@ -23,14 +27,6 @@ class FeedItemCell: UITableViewCell {
             
             containerView.addSubview(playerView)
             playerView.constraintToSuperview()
-        }
-    }
-    
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        
-        for view in containerView.subviews {
-            view.removeFromSuperview()
         }
     }
     

--- a/JWBestPracticeApps/FeedTableViewController/FeedTableViewController.swift
+++ b/JWBestPracticeApps/FeedTableViewController/FeedTableViewController.swift
@@ -57,34 +57,10 @@ class FeedTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FeedItemCellIdentifier, for: indexPath) as! FeedItemCell
         
-        // Get player from the feed array
-        let player = feed[indexPath.row]
-        
         // Add player view to the container view of the cell
-        if let playerView = player.view {
-            cell.containerView.addSubview(playerView)
-            playerView.constraintToSuperview()
-        }
+        cell.player = feed[indexPath.row]
         
         return cell
-    }
-
-//  MARK: UISCrollViewDelegate implementation
-    
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let visibleIndexPaths = tableView.indexPathsForVisibleRows else { return }
-
-        // Map rows as indexes
-        let visibleRows = visibleIndexPaths.map({ return $0.row })
-        // Check for non-visible players inside the feed
-        let nonVisiblePlayers = feed.enumerated().filter { (offset: Int, player: JWPlayerController) -> Bool in
-            return !visibleRows.contains(offset) && player.state == JWPlayerState.playing
-        }
-        // Iterate non-visible players to pause the video and remove the previous view from cell
-        nonVisiblePlayers.forEach { (_, player: JWPlayerController) in
-            player.pause()
-            player.view?.removeFromSuperview()
-        }
     }
     
 }


### PR DESCRIPTION
Removed scrolling monitoring which caused jitter by calling pause() and filtering the players with every small amount of scrolling.

Moved TableCell UI code into the FeedItemCell, where now it removes the subviews of the container view on prepareForReuse(). It also takes a player as an argument, and adds the view to the container itself.