### PR TITLE
dk 4723

### DIFF
--- a/JWBestPracticeApps/JWAirPlay/Base.lproj/Main.storyboard
+++ b/JWBestPracticeApps/JWAirPlay/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ACu-ch-C5b">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Air Play View Controller-->
@@ -14,13 +16,31 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <navigationItem key="navigationItem" id="OXc-aJ-oPW"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="34" y="31"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="wvd-eq-7ga">
+            <objects>
+                <navigationController id="ACu-ch-C5b" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="I2I-FP-25g">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="US2-5b-Nv8"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Vh5-7h-sGI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-809" y="31"/>
         </scene>
     </scenes>
 </document>

--- a/JWBestPracticeApps/JWAirPlay/JWAirPlayViewController.m
+++ b/JWBestPracticeApps/JWAirPlay/JWAirPlayViewController.m
@@ -7,11 +7,10 @@
 //
 
 #import "JWAirPlayViewController.h"
+#import <AVKit/AVKit.h>
 #import <MediaPlayer/MediaPlayer.h>
 
 @interface JWAirPlayViewController ()
-
-@property (nonatomic) MPVolumeView *airPlayView;
 
 @end
 
@@ -20,18 +19,32 @@
 -(void)viewDidLoad
 {
     [super viewDidLoad];
+    
     [self setUpAirPlayButton];
 }
 
 - (void)setUpAirPlayButton
 {
-    CGFloat buttonWidth = 44;
-    CGFloat buttonCoordinateX = self.player.view.frame.size.width - buttonWidth - 5;
-    self.airPlayView =[[MPVolumeView alloc] initWithFrame:CGRectMake(buttonCoordinateX, 0, buttonWidth, buttonWidth)];
-    [self.airPlayView setShowsVolumeSlider:NO];
-    self.airPlayView.backgroundColor = [UIColor clearColor];
-    self.airPlayView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
-    [self.player.view addSubview:self.airPlayView];
+    UIView *buttonView = [[UIView new] init];
+    CGRect buttonFrame = CGRectMake(0, 0, 50, 50);
+    
+    if (@available(iOS 11, *)) {
+        // Creating an instance of AVRouteDetector causes AVRoutePickerView to correctly apply
+        // the activeTintColor.
+        AVRouteDetector *routeDetector = [[AVRouteDetector new] init];
+        AVRoutePickerView *airplayButton = [[AVRoutePickerView alloc] initWithFrame: buttonFrame];
+        airplayButton.activeTintColor = UIColor.blueColor;
+        airplayButton.tintColor = UIColor.grayColor;
+        buttonView = airplayButton;
+    } else {
+        MPVolumeView *airplayButton = [[MPVolumeView alloc] initWithFrame: buttonFrame];
+        airplayButton.showsVolumeSlider = false;
+        buttonView = airplayButton;
+    }
+    
+    // If there is not AirPlay devices available, the button will not be displayed.
+    UIBarButtonItem *barButtonItem = [[UIBarButtonItem alloc] initWithCustomView: buttonView];
+    [self.navigationItem setRightBarButtonItem: barButtonItem animated: true];
 }
 
 @end

--- a/JWBestPracticeApps/JWBestPracticeApps.xcodeproj/project.pbxproj
+++ b/JWBestPracticeApps/JWBestPracticeApps.xcodeproj/project.pbxproj
@@ -1727,6 +1727,7 @@
 				TargetAttributes = {
 					3B181AD223592D5A003D4CDB = {
 						CreatedOnToolsVersion = 11.1;
+						DevelopmentTeam = WX87M56X5N;
 						ProvisioningStyle = Automatic;
 					};
 					793AA63E231ED916006CA8FF = {
@@ -3434,6 +3435,7 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.AirPlay;
 				PRODUCT_NAME = AirPlay;
 			};
 			name = Debug;
@@ -3444,6 +3446,7 @@
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.AirPlay;
 				PRODUCT_NAME = AirPlay;
 			};
 			name = Release;
@@ -3467,15 +3470,18 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.FeedCollectionViewController;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayerSDK.FeedCollectionViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "FeedCollectionViewController/FeedCollectionViewController-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -3503,14 +3509,17 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.FeedCollectionViewController;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayerSDK.FeedCollectionViewController;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "FeedCollectionViewController/FeedCollectionViewController-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/JWBestPracticeApps/JWBestPracticeApps/Info.plist
+++ b/JWBestPracticeApps/JWBestPracticeApps/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>JWPlayerKey</key>
-	<string></string>
+	<string>wcMVWRVrbdn7XExOs8rURPdAVDd3Se+WKYd1mRhyxwvX/iAXfoiIENKJH65G0WN2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/JWBestPracticeApps/JWBestPracticeApps/Info.plist
+++ b/JWBestPracticeApps/JWBestPracticeApps/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>JWPlayerKey</key>
-	<string>wcMVWRVrbdn7XExOs8rURPdAVDd3Se+WKYd1mRhyxwvX/iAXfoiIENKJH65G0WN2</string>
+	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Updates JWAirPlay BestPracticeApp to use the AVRoutePickerView control after iOS 11 and keeps using MPVolumeView control for previous iOS versions.