### PR TITLE
[SDK-4953] Added bluetooth usage description to the info.plist

### DIFF
--- a/JWBestPracticeApps/JWBestPracticeApps/Info.plist
+++ b/JWBestPracticeApps/JWBestPracticeApps/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Used to enable Google Casting.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
With iOS 13, Apple has introduced stricter permission requirements that impact apps using the Google Cast SDK. The 'NSBluetoothAlwaysUsageDescription' key is necessary on iOS 13 to run the Casting and JWCasting best practice apps without crashing.