### PR TITLE
[SDK-5976] Best practice apps to showcase how to use 'displayLockScreenControls'

### DIFF
--- a/JWBestPracticeApps/JWBestPracticeApps.xcodeproj/project.pbxproj
+++ b/JWBestPracticeApps/JWBestPracticeApps.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		241E580FC2D205BE0EC949F2 /* libPods-JWConviva.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB03385796BF497EAF7D828 /* libPods-JWConviva.a */; };
 		28208CD343CB17680351BF5E /* libPods-JWRemoteCastController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 425248D5C63F33974B439BBD /* libPods-JWRemoteCastController.a */; };
 		29984DE6822C398DD72713E3 /* libPods-VoicerExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 07937315AF7025E0211FC774 /* libPods-VoicerExtension.a */; };
+		2A874C6B328AC080646EC594 /* libPods-JWLockScreenControls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2691EC4C11D5D3B57241FD33 /* libPods-JWLockScreenControls.a */; };
 		2F1594C1682C62547ED0C4C2 /* libPods-NativeControls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B51316CA7D5F2026AA26704 /* libPods-NativeControls.a */; };
 		36223933F3CDADE14DD2852E /* libPods-GoogleDAI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8EC1026C52301A1B864E01 /* libPods-GoogleDAI.a */; };
 		3B181AD623592D5A003D4CDB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B181AD523592D5A003D4CDB /* AppDelegate.swift */; };
@@ -22,6 +23,17 @@
 		3B181AEE23592DD1003D4CDB /* Feed.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B181AED23592DD1003D4CDB /* Feed.plist */; };
 		3B181AF023592DE5003D4CDB /* FeedCollectionViewController-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B181AEF23592DE5003D4CDB /* FeedCollectionViewController-Bridging-Header.h */; };
 		3B181AF223592DEF003D4CDB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B181AF123592DEF003D4CDB /* Main.storyboard */; };
+		3BA8F763247CAB53000190DF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA8F762247CAB53000190DF /* AppDelegate.swift */; };
+		3BA8F76A247CAB53000190DF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F768247CAB53000190DF /* Main.storyboard */; };
+		3BA8F76C247CAB55000190DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F76B247CAB55000190DF /* Assets.xcassets */; };
+		3BA8F76F247CAB55000190DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F76D247CAB55000190DF /* LaunchScreen.storyboard */; };
+		3BA8F775247CABC4000190DF /* LockScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA8F774247CABC4000190DF /* LockScreenViewController.swift */; };
+		3BA8F77F247CAC8D000190DF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA8F77E247CAC8D000190DF /* AppDelegate.m */; };
+		3BA8F788247CAC8D000190DF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F786247CAC8D000190DF /* Main.storyboard */; };
+		3BA8F78A247CAC8F000190DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F789247CAC8F000190DF /* Assets.xcassets */; };
+		3BA8F78D247CAC8F000190DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BA8F78B247CAC8F000190DF /* LaunchScreen.storyboard */; };
+		3BA8F790247CAC8F000190DF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA8F78F247CAC8F000190DF /* main.m */; };
+		3BA8F795247CAE6F000190DF /* JWLockScreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA8F794247CAE6F000190DF /* JWLockScreenViewController.m */; };
 		3BBF80C2235DEAF100C529DF /* FeedItemCell+JWPlayerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBF80C1235DEAF100C529DF /* FeedItemCell+JWPlayerDelegate.swift */; };
 		403AE5E288657240D7201522 /* libPods-JWRemoteController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6960B809E87D90EBF1ADFC17 /* libPods-JWRemoteController.a */; };
 		47595BB3E8D0E95FABB1E764 /* libPods-FeedTableViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3442318C4BDA2CFB2694337 /* libPods-FeedTableViewController.a */; };
@@ -217,6 +229,7 @@
 		B5D57384243394BD0043BC77 /* BasicVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79AADBB9231DB01100E8B48D /* BasicVideoViewController.swift */; };
 		C13716CBFBD2EF342EA7DC83 /* libPods-JWBestPracticeApps.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D48D6A378553044B19BF12D /* libPods-JWBestPracticeApps.a */; };
 		C3FCDF396365267CFDDD66CA /* libPods-BasicVideoViewController.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E13EF4956176DC291C53FA20 /* libPods-BasicVideoViewController.a */; };
+		C9C3F273B3F0183A790BADF1 /* libPods-LockScreenControls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D89D2DD4CDA5480843B2432F /* libPods-LockScreenControls.a */; };
 		D12823F5CF4AC080C0AC3B08 /* libPods-AutoplayVideoFeed.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4103B27105FFE328AA0A621 /* libPods-AutoplayVideoFeed.a */; };
 		DD78E95E5958215D5053AEB0 /* libPods-JWRemotePlayer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FB0C54926510AB9F4F09374 /* libPods-JWRemotePlayer.a */; };
 		E5A7BC5034AE3E5574B0DD19 /* libPods-AirPlay.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BD9A51F82F1B6BCB5F5EEAC /* libPods-AirPlay.a */; };
@@ -347,6 +360,7 @@
 		1BDA9C423F815F7BA9B2A3EB /* Pods-BasicVideoViewController.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BasicVideoViewController.release.xcconfig"; path = "Target Support Files/Pods-BasicVideoViewController/Pods-BasicVideoViewController.release.xcconfig"; sourceTree = "<group>"; };
 		1C594E3DFE758735A73160A9 /* Pods-JWRemotePlayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWRemotePlayer.debug.xcconfig"; path = "Target Support Files/Pods-JWRemotePlayer/Pods-JWRemotePlayer.debug.xcconfig"; sourceTree = "<group>"; };
 		20C50DE3833B8FAE53F03BBB /* Pods-BasicVideoViewController.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BasicVideoViewController.debug.xcconfig"; path = "Target Support Files/Pods-BasicVideoViewController/Pods-BasicVideoViewController.debug.xcconfig"; sourceTree = "<group>"; };
+		2691EC4C11D5D3B57241FD33 /* libPods-JWLockScreenControls.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWLockScreenControls.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		282FAA8D01A4F638EF920270 /* Pods-JWAirPlay.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWAirPlay.debug.xcconfig"; path = "Target Support Files/Pods-JWAirPlay/Pods-JWAirPlay.debug.xcconfig"; sourceTree = "<group>"; };
 		2B36A679E09946216E9593CE /* libPods-Casting.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Casting.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2EAAD561A6E20B3D7DA378BA /* libPods-JWFairPlayDrm.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWFairPlayDrm.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -362,6 +376,22 @@
 		3B181AEF23592DE5003D4CDB /* FeedCollectionViewController-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FeedCollectionViewController-Bridging-Header.h"; sourceTree = "<group>"; };
 		3B181AF123592DEF003D4CDB /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		3B1AD39A2354BEAD002A15D8 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
+		3BA8F760247CAB53000190DF /* LockScreenControls.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LockScreenControls.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BA8F762247CAB53000190DF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		3BA8F769247CAB53000190DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3BA8F76B247CAB55000190DF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3BA8F76E247CAB55000190DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3BA8F774247CABC4000190DF /* LockScreenViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenViewController.swift; sourceTree = "<group>"; };
+		3BA8F776247CABFE000190DF /* LockScreenControls-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LockScreenControls-Bridging-Header.h"; sourceTree = "<group>"; };
+		3BA8F77B247CAC8D000190DF /* JWLockScreenControls.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JWLockScreenControls.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BA8F77D247CAC8D000190DF /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		3BA8F77E247CAC8D000190DF /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		3BA8F787247CAC8D000190DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3BA8F789247CAC8F000190DF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3BA8F78C247CAC8F000190DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3BA8F78F247CAC8F000190DF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		3BA8F794247CAE6F000190DF /* JWLockScreenViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JWLockScreenViewController.m; sourceTree = "<group>"; };
+		3BA8F796247CAF6A000190DF /* JWLockScreenViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JWLockScreenViewController.h; sourceTree = "<group>"; };
 		3BBF80C1235DEAF100C529DF /* FeedItemCell+JWPlayerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedItemCell+JWPlayerDelegate.swift"; sourceTree = "<group>"; };
 		3E6AD99A58F7227B7941CDC4 /* Pods-JWRemoteCastController Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWRemoteCastController Extension.release.xcconfig"; path = "Target Support Files/Pods-JWRemoteCastController Extension/Pods-JWRemoteCastController Extension.release.xcconfig"; sourceTree = "<group>"; };
 		3EE58766402AA1E1EE9C57A8 /* Pods-JWRemotePlayer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWRemotePlayer.release.xcconfig"; path = "Target Support Files/Pods-JWRemotePlayer/Pods-JWRemotePlayer.release.xcconfig"; sourceTree = "<group>"; };
@@ -369,6 +399,7 @@
 		456C13E5F37B81C27CDF6B32 /* libPods-JWRemoteCastPlayer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWRemoteCastPlayer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C4B45DA9AE03224633B70CA /* Pods-JWConviva.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWConviva.debug.xcconfig"; path = "Target Support Files/Pods-JWConviva/Pods-JWConviva.debug.xcconfig"; sourceTree = "<group>"; };
 		4C95C3797160E37CE592DC28 /* Pods-JWBestPracticeApps.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWBestPracticeApps.release.xcconfig"; path = "Target Support Files/Pods-JWBestPracticeApps/Pods-JWBestPracticeApps.release.xcconfig"; sourceTree = "<group>"; };
+		5D79557EB5461D5407C4964A /* Pods-JWLockScreenControls.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWLockScreenControls.release.xcconfig"; path = "Target Support Files/Pods-JWLockScreenControls/Pods-JWLockScreenControls.release.xcconfig"; sourceTree = "<group>"; };
 		6960B809E87D90EBF1ADFC17 /* libPods-JWRemoteController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWRemoteController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B51316CA7D5F2026AA26704 /* libPods-NativeControls.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeControls.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BD9A51F82F1B6BCB5F5EEAC /* libPods-AirPlay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirPlay.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -565,6 +596,7 @@
 		B5BC26A81D958BFF00F32770 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en; path = en.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		B5BC26AC1D97B25B00F32770 /* VoicerExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VoicerExtension.entitlements; sourceTree = "<group>"; };
 		B5BC26B11DAC20E500F32770 /* info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = info.plist; sourceTree = "<group>"; };
+		B843BABE0BBB11860C65E8EC /* Pods-JWLockScreenControls.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWLockScreenControls.debug.xcconfig"; path = "Target Support Files/Pods-JWLockScreenControls/Pods-JWLockScreenControls.debug.xcconfig"; sourceTree = "<group>"; };
 		BC8BED0908290A1C60AFBC5C /* libPods-JWRemoteCastController Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWRemoteCastController Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C378B3A75ADCC82FB8846185 /* Pods-NativeControls.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeControls.debug.xcconfig"; path = "Target Support Files/Pods-NativeControls/Pods-NativeControls.debug.xcconfig"; sourceTree = "<group>"; };
 		C7DD1EFB4D03D4722EA6EAD7 /* libPods-JWFriendlyObstructions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWFriendlyObstructions.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -575,6 +607,7 @@
 		D100732D98416FDBC8C3253D /* Pods-VoicerExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoicerExtension.release.xcconfig"; path = "Target Support Files/Pods-VoicerExtension/Pods-VoicerExtension.release.xcconfig"; sourceTree = "<group>"; };
 		D3442318C4BDA2CFB2694337 /* libPods-FeedTableViewController.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FeedTableViewController.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D61FCFCF572B03B4F7F0E2BD /* Pods-VoicerExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VoicerExtension.debug.xcconfig"; path = "Target Support Files/Pods-VoicerExtension/Pods-VoicerExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		D89D2DD4CDA5480843B2432F /* libPods-LockScreenControls.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LockScreenControls.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB6939FD85E49626B97F3751 /* Pods-Voicer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Voicer.debug.xcconfig"; path = "Target Support Files/Pods-Voicer/Pods-Voicer.debug.xcconfig"; sourceTree = "<group>"; };
 		DB8EC1026C52301A1B864E01 /* libPods-GoogleDAI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-GoogleDAI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBFC4C3291FA6600375E85C1 /* Pods-FeedTableViewController.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FeedTableViewController.release.xcconfig"; path = "Target Support Files/Pods-FeedTableViewController/Pods-FeedTableViewController.release.xcconfig"; sourceTree = "<group>"; };
@@ -582,6 +615,7 @@
 		E4103B27105FFE328AA0A621 /* libPods-AutoplayVideoFeed.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoplayVideoFeed.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBEAA6F3D6F5977A7FBC8E60 /* Pods-AutoplayVideoFeed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoplayVideoFeed.debug.xcconfig"; path = "Target Support Files/Pods-AutoplayVideoFeed/Pods-AutoplayVideoFeed.debug.xcconfig"; sourceTree = "<group>"; };
 		ED75868A3C309D3E04F2C1C0 /* Pods-JWRemoteCastController Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWRemoteCastController Extension.debug.xcconfig"; path = "Target Support Files/Pods-JWRemoteCastController Extension/Pods-JWRemoteCastController Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		EFCE0CC4A03170C5AF436821 /* Pods-LockScreenControls.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LockScreenControls.release.xcconfig"; path = "Target Support Files/Pods-LockScreenControls/Pods-LockScreenControls.release.xcconfig"; sourceTree = "<group>"; };
 		F262415913389DE545421F1A /* Pods-JWRemoteController.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWRemoteController.release.xcconfig"; path = "Target Support Files/Pods-JWRemoteController/Pods-JWRemoteController.release.xcconfig"; sourceTree = "<group>"; };
 		F4EC778C223FD43F0008B8DB /* JWConviva.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JWConviva.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4EC778E223FD43F0008B8DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -592,6 +626,7 @@
 		F4EC779E223FD6C60008B8DB /* AnalyticsObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsObserver.swift; sourceTree = "<group>"; };
 		F4EC77A0223FD86F0008B8DB /* JWConviva-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JWConviva-Bridging-Header.h"; sourceTree = "<group>"; };
 		F5438031931B93B1B4ECFC3E /* Pods-JWBestPracticeApps.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWBestPracticeApps.debug.xcconfig"; path = "Target Support Files/Pods-JWBestPracticeApps/Pods-JWBestPracticeApps.debug.xcconfig"; sourceTree = "<group>"; };
+		F6A33260A60637325E083437 /* Pods-LockScreenControls.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LockScreenControls.debug.xcconfig"; path = "Target Support Files/Pods-LockScreenControls/Pods-LockScreenControls.debug.xcconfig"; sourceTree = "<group>"; };
 		F708B5D070F45F3E2E359403 /* libPods-JWRemoteController Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JWRemoteController Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F807AC4E723C1C3CD57C3022 /* Pods-JWFriendlyObstructions.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JWFriendlyObstructions.debug.xcconfig"; path = "Target Support Files/Pods-JWFriendlyObstructions/Pods-JWFriendlyObstructions.debug.xcconfig"; sourceTree = "<group>"; };
 		F8CD3AF40EC8C0E12C1460F1 /* Pods-AirPlay.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirPlay.release.xcconfig"; path = "Target Support Files/Pods-AirPlay/Pods-AirPlay.release.xcconfig"; sourceTree = "<group>"; };
@@ -620,6 +655,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				1559D1289928060378D5112E /* libPods-FeedCollectionViewController.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F75D247CAB53000190DF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9C3F273B3F0183A790BADF1 /* libPods-LockScreenControls.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F778247CAC8D000190DF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A874C6B328AC080646EC594 /* libPods-JWLockScreenControls.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,6 +845,34 @@
 			path = FeedCollectionViewController;
 			sourceTree = "<group>";
 		};
+		3BA8F761247CAB53000190DF /* LockScreenControls */ = {
+			isa = PBXGroup;
+			children = (
+				3BA8F762247CAB53000190DF /* AppDelegate.swift */,
+				3BA8F774247CABC4000190DF /* LockScreenViewController.swift */,
+				3BA8F768247CAB53000190DF /* Main.storyboard */,
+				3BA8F76B247CAB55000190DF /* Assets.xcassets */,
+				3BA8F76D247CAB55000190DF /* LaunchScreen.storyboard */,
+				3BA8F776247CABFE000190DF /* LockScreenControls-Bridging-Header.h */,
+			);
+			path = LockScreenControls;
+			sourceTree = "<group>";
+		};
+		3BA8F77C247CAC8D000190DF /* JWLockScreenControls */ = {
+			isa = PBXGroup;
+			children = (
+				3BA8F77D247CAC8D000190DF /* AppDelegate.h */,
+				3BA8F77E247CAC8D000190DF /* AppDelegate.m */,
+				3BA8F796247CAF6A000190DF /* JWLockScreenViewController.h */,
+				3BA8F794247CAE6F000190DF /* JWLockScreenViewController.m */,
+				3BA8F786247CAC8D000190DF /* Main.storyboard */,
+				3BA8F789247CAC8F000190DF /* Assets.xcassets */,
+				3BA8F78B247CAC8F000190DF /* LaunchScreen.storyboard */,
+				3BA8F78F247CAC8F000190DF /* main.m */,
+			);
+			path = JWLockScreenControls;
+			sourceTree = "<group>";
+		};
 		52AC3655A45B0438BEB4426C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -821,6 +900,8 @@
 				ADF5F56C189FDF316F706FE9 /* libPods-FeedCollectionViewController.a */,
 				E4103B27105FFE328AA0A621 /* libPods-AutoplayVideoFeed.a */,
 				DB8EC1026C52301A1B864E01 /* libPods-GoogleDAI.a */,
+				2691EC4C11D5D3B57241FD33 /* libPods-JWLockScreenControls.a */,
+				D89D2DD4CDA5480843B2432F /* libPods-LockScreenControls.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -999,6 +1080,7 @@
 			isa = PBXGroup;
 			children = (
 				8A729A791C98ACA8000F03A9 /* JWBestPracticeApps */,
+				3BA8F77C247CAC8D000190DF /* JWLockScreenControls */,
 				8A729B101C98B5A6000F03A9 /* JWCasting */,
 				8A729B2B1C98B5F2000F03A9 /* JWAirPlay */,
 				8A9206371C9B4E67002797FA /* Watch App */,
@@ -1011,6 +1093,7 @@
 				7988D94F2304717E0043CE80 /* FeedTableViewController */,
 				79AADBB6231DB01100E8B48D /* BasicVideoViewController */,
 				79CAAD2E2321D0FC002FFA23 /* NativeControls */,
+				3BA8F761247CAB53000190DF /* LockScreenControls */,
 				793AA640231ED916006CA8FF /* Casting */,
 				79E3CC1E234E6FAB00EA07CA /* AirPlay */,
 				3B181AD423592D5A003D4CDB /* FeedCollectionViewController */,
@@ -1047,6 +1130,8 @@
 				3B181AD323592D5A003D4CDB /* FeedCollectionViewController.app */,
 				807A647224341EB7000AE243 /* AutoplayVideoFeed.app */,
 				807A644E24323041000AE243 /* GoogleDAI.app */,
+				3BA8F760247CAB53000190DF /* LockScreenControls.app */,
+				3BA8F77B247CAC8D000190DF /* JWLockScreenControls.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1313,6 +1398,10 @@
 				7FD194FE2E1C85B817E2B223 /* Pods-AutoplayVideoFeed.release.xcconfig */,
 				9BDAA5202DF6B9A446A397BA /* Pods-GoogleDAI.debug.xcconfig */,
 				83551FA4EC9B0C6AA134CC01 /* Pods-GoogleDAI.release.xcconfig */,
+				B843BABE0BBB11860C65E8EC /* Pods-JWLockScreenControls.debug.xcconfig */,
+				5D79557EB5461D5407C4964A /* Pods-JWLockScreenControls.release.xcconfig */,
+				F6A33260A60637325E083437 /* Pods-LockScreenControls.debug.xcconfig */,
+				EFCE0CC4A03170C5AF436821 /* Pods-LockScreenControls.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1434,6 +1523,44 @@
 			name = FeedCollectionViewController;
 			productName = FeedCollectionViewController;
 			productReference = 3B181AD323592D5A003D4CDB /* FeedCollectionViewController.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3BA8F75F247CAB53000190DF /* LockScreenControls */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3BA8F773247CAB55000190DF /* Build configuration list for PBXNativeTarget "LockScreenControls" */;
+			buildPhases = (
+				004CDD86DCEAE2B290D514EF /* [CP] Check Pods Manifest.lock */,
+				3BA8F75C247CAB53000190DF /* Sources */,
+				3BA8F75D247CAB53000190DF /* Frameworks */,
+				3BA8F75E247CAB53000190DF /* Resources */,
+				B44619EAE4DD98436C365ADD /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LockScreenControls;
+			productName = LockScreenControls;
+			productReference = 3BA8F760247CAB53000190DF /* LockScreenControls.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3BA8F77A247CAC8D000190DF /* JWLockScreenControls */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3BA8F791247CAC8F000190DF /* Build configuration list for PBXNativeTarget "JWLockScreenControls" */;
+			buildPhases = (
+				F2BADA7E1CAECF754615B2DE /* [CP] Check Pods Manifest.lock */,
+				3BA8F777247CAC8D000190DF /* Sources */,
+				3BA8F778247CAC8D000190DF /* Frameworks */,
+				3BA8F779247CAC8D000190DF /* Resources */,
+				0D8415B06E48DE416A81C799 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JWLockScreenControls;
+			productName = JWLockScreenControls;
+			productReference = 3BA8F77B247CAC8D000190DF /* JWLockScreenControls.app */;
 			productType = "com.apple.product-type.application";
 		};
 		793AA63E231ED916006CA8FF /* Casting */ = {
@@ -1857,12 +1984,22 @@
 		8A729A6F1C98ACA8000F03A9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 1140;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Karim Mourra";
 				TargetAttributes = {
 					3B181AD223592D5A003D4CDB = {
 						CreatedOnToolsVersion = 11.1;
+						DevelopmentTeam = WX87M56X5N;
+						ProvisioningStyle = Automatic;
+					};
+					3BA8F75F247CAB53000190DF = {
+						CreatedOnToolsVersion = 11.4.1;
+						DevelopmentTeam = WX87M56X5N;
+						ProvisioningStyle = Automatic;
+					};
+					3BA8F77A247CAC8D000190DF = {
+						CreatedOnToolsVersion = 11.4.1;
 						DevelopmentTeam = WX87M56X5N;
 						ProvisioningStyle = Automatic;
 					};
@@ -2036,6 +2173,8 @@
 				3B181AD223592D5A003D4CDB /* FeedCollectionViewController */,
 				807A647124341EB7000AE243 /* AutoplayVideoFeed */,
 				807A644D24323041000AE243 /* GoogleDAI */,
+				3BA8F75F247CAB53000190DF /* LockScreenControls */,
+				3BA8F77A247CAC8D000190DF /* JWLockScreenControls */,
 			);
 		};
 /* End PBXProject section */
@@ -2049,6 +2188,26 @@
 				3B181AE223592D5B003D4CDB /* LaunchScreen.storyboard in Resources */,
 				3B181ADF23592D5B003D4CDB /* Assets.xcassets in Resources */,
 				3B181AF223592DEF003D4CDB /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F75E247CAB53000190DF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BA8F76F247CAB55000190DF /* LaunchScreen.storyboard in Resources */,
+				3BA8F76C247CAB55000190DF /* Assets.xcassets in Resources */,
+				3BA8F76A247CAB53000190DF /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F779247CAC8D000190DF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BA8F78D247CAC8F000190DF /* LaunchScreen.storyboard in Resources */,
+				3BA8F78A247CAC8F000190DF /* Assets.xcassets in Resources */,
+				3BA8F788247CAC8D000190DF /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2291,6 +2450,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		004CDD86DCEAE2B290D514EF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LockScreenControls-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		0CC9F8C8D4BF93616BD7BBE0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2311,6 +2492,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0D8415B06E48DE416A81C799 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-JWLockScreenControls/Pods-JWLockScreenControls-frameworks.sh",
+				"${PODS_ROOT}/JWPlayer-SDK/JWPlayer_iOS_SDK.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JWPlayer_iOS_SDK.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-JWLockScreenControls/Pods-JWLockScreenControls-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		112561D497DCDC73655A243F /* [CP] Check Pods Manifest.lock */ = {
@@ -3005,6 +3204,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		B44619EAE4DD98436C365ADD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-LockScreenControls/Pods-LockScreenControls-frameworks.sh",
+				"${PODS_ROOT}/JWPlayer-SDK/JWPlayer_iOS_SDK.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JWPlayer_iOS_SDK.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LockScreenControls/Pods-LockScreenControls-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C1F5DFBDC63DAEBD7E99AF91 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3183,6 +3400,28 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AirPlay/Pods-AirPlay-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		F2BADA7E1CAECF754615B2DE /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-JWLockScreenControls-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		F7A309182EDA99C2E17748D9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3216,6 +3455,25 @@
 				3B181AEC23592DC9003D4CDB /* FeedItemCell.swift in Sources */,
 				3B181AEA23592DC0003D4CDB /* FeedCollectionViewController.swift in Sources */,
 				3B181AD623592D5A003D4CDB /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F75C247CAB53000190DF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BA8F775247CABC4000190DF /* LockScreenViewController.swift in Sources */,
+				3BA8F763247CAB53000190DF /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3BA8F777247CAC8D000190DF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3BA8F77F247CAC8D000190DF /* AppDelegate.m in Sources */,
+				3BA8F790247CAC8F000190DF /* main.m in Sources */,
+				3BA8F795247CAE6F000190DF /* JWLockScreenViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3447,6 +3705,38 @@
 			isa = PBXVariantGroup;
 			children = (
 				3B181AE123592D5B003D4CDB /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		3BA8F768247CAB53000190DF /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3BA8F769247CAB53000190DF /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3BA8F76D247CAB55000190DF /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3BA8F76E247CAB55000190DF /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		3BA8F786247CAC8D000190DF /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3BA8F787247CAC8D000190DF /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3BA8F78B247CAC8F000190DF /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3BA8F78C247CAC8F000190DF /* Base */,
 			);
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
@@ -3828,6 +4118,140 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "FeedCollectionViewController/FeedCollectionViewController-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3BA8F771247CAB55000190DF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F6A33260A60637325E083437 /* Pods-LockScreenControls.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.LockScreenControls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3BA8F772247CAB55000190DF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EFCE0CC4A03170C5AF436821 /* Pods-LockScreenControls.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.LockScreenControls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3BA8F792247CAC8F000190DF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B843BABE0BBB11860C65E8EC /* Pods-JWLockScreenControls.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.JWLockScreenControls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3BA8F793247CAC8F000190DF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5D79557EB5461D5407C4964A /* Pods-JWLockScreenControls.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WX87M56X5N;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = JWBestPracticeApps/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = JWPlayer.JWLockScreenControls;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -4881,6 +5305,24 @@
 			buildConfigurations = (
 				3B181AE623592D5B003D4CDB /* Debug */,
 				3B181AE723592D5B003D4CDB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3BA8F773247CAB55000190DF /* Build configuration list for PBXNativeTarget "LockScreenControls" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3BA8F771247CAB55000190DF /* Debug */,
+				3BA8F772247CAB55000190DF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3BA8F791247CAC8F000190DF /* Build configuration list for PBXNativeTarget "JWLockScreenControls" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3BA8F792247CAC8F000190DF /* Debug */,
+				3BA8F793247CAC8F000190DF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JWBestPracticeApps/JWLockScreenControls/AppDelegate.h
+++ b/JWBestPracticeApps/JWLockScreenControls/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  JWLockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end
+
+

--- a/JWBestPracticeApps/JWLockScreenControls/AppDelegate.m
+++ b/JWBestPracticeApps/JWLockScreenControls/AppDelegate.m
@@ -1,0 +1,33 @@
+//
+//  AppDelegate.m
+//  JWLockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#import "AppDelegate.h"
+#import "AVKit/AVKit.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+
+    NSError *error;
+    [AVAudioSession.sharedInstance setCategory:AVAudioSessionCategoryPlayback error:&error];
+    [AVAudioSession.sharedInstance setActive:YES error:&error];
+
+    if (error) {
+        NSLog(@"Error setting audio session: %@", error);
+    }
+
+    return YES;
+}
+
+@end

--- a/JWBestPracticeApps/JWLockScreenControls/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JWBestPracticeApps/JWLockScreenControls/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/JWLockScreenControls/Assets.xcassets/Contents.json
+++ b/JWBestPracticeApps/JWLockScreenControls/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/JWLockScreenControls/Base.lproj/LaunchScreen.storyboard
+++ b/JWBestPracticeApps/JWLockScreenControls/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/JWBestPracticeApps/JWLockScreenControls/Base.lproj/Main.storyboard
+++ b/JWBestPracticeApps/JWLockScreenControls/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Lock Screen View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="JWLockScreenViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="110"/>
+        </scene>
+    </scenes>
+</document>

--- a/JWBestPracticeApps/JWLockScreenControls/JWLockScreenViewController.h
+++ b/JWBestPracticeApps/JWLockScreenControls/JWLockScreenViewController.h
@@ -1,0 +1,15 @@
+//
+//  JWLockScreenViewController.h
+//  JWLockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <JWPlayer_iOS_SDK/JWPlayerController.h>
+
+@interface JWLockScreenViewController : UIViewController
+
+
+@end

--- a/JWBestPracticeApps/JWLockScreenControls/JWLockScreenViewController.m
+++ b/JWBestPracticeApps/JWLockScreenControls/JWLockScreenViewController.m
@@ -1,0 +1,74 @@
+//
+//  JWLockScreenViewController.m
+//  JWLockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#import "JWLockScreenViewController.h"
+
+@interface JWLockScreenViewController ()
+
+@property (nonatomic) JWPlayerController *topPlayer;
+@property (nonatomic) JWPlayerController *bottomPlayer;
+
+@end
+
+@implementation JWLockScreenViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    [self createTopPlayer];
+    [self createBottomPlayer];
+
+    // After all players have been instantiated, make sure 'displayLockScreenControls' is set to false for all the players
+    // you don't want to be affected by lock screen controls. Then, set 'displayLockScreenControls' true
+    // for the player you do want the lock screen controls to affect.
+
+    self.bottomPlayer.displayLockScreenControls = NO; // Won't be affected by lock screen controls
+    self.topPlayer.displayLockScreenControls = YES; // Will be affected by lock screen controls
+
+    // Note: - If a third player is instantiated, it will take over the current lock screen controls,
+    // because 'displayLockScreenControls' defaults to true.
+}
+
+- (void)createTopPlayer
+{
+    NSString *videoURL = @"http://playertest.longtailvideo.com/adaptive/oceans/oceans.m3u8";
+    NSString *posterImageURL = @"http://d3el35u4qe4frz.cloudfront.net/bkaovAYt-480.jpg";
+    JWConfig *config = [[JWConfig alloc] initWithContentUrl:videoURL];
+    config.image = posterImageURL;
+    config.title = @"Top Player";
+    config.autostart = YES;
+    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewHeight = self.view.frame.size.height;
+    config.size = CGSizeMake(viewWidth, viewHeight/2);
+    self.topPlayer = [[JWPlayerController alloc] initWithConfig:config];
+    [self.view addSubview:self.topPlayer.view];
+    CGFloat midX = self.view.frame.size.width / 2;
+    CGFloat midY = self.view.frame.size.height / 2;
+    self.topPlayer.view.center = CGPointMake(midX, midY - (config.size.height/2));
+}
+
+- (void)createBottomPlayer
+{
+    NSString *videoURL = @"https://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.m3u8";
+    NSString *posterImageURL = @"http://d3el35u4qe4frz.cloudfront.net/3XnJSIm4-480.jpg";
+    JWConfig *config = [[JWConfig alloc] initWithContentUrl:videoURL];
+    config.image = posterImageURL;
+    config.title = @"Bottom Player";
+    config.autostart = YES;
+    CGFloat viewWidth = self.view.frame.size.width;
+    CGFloat viewHeight = self.view.frame.size.height;
+    config.size = CGSizeMake(viewWidth, viewHeight/2);
+    self.bottomPlayer = [[JWPlayerController alloc] initWithConfig:config];
+    [self.view addSubview:self.bottomPlayer.view];
+    CGFloat midX = self.view.frame.size.width / 2;
+    CGFloat midY = self.view.frame.size.height / 2;
+    self.bottomPlayer.view.center = CGPointMake(midX, midY + (config.size.height/2));
+}
+
+
+@end

--- a/JWBestPracticeApps/JWLockScreenControls/main.m
+++ b/JWBestPracticeApps/JWLockScreenControls/main.m
@@ -1,0 +1,19 @@
+//
+//  main.m
+//  JWLockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/JWBestPracticeApps/LockScreenControls/AppDelegate.swift
+++ b/JWBestPracticeApps/LockScreenControls/AppDelegate.swift
@@ -1,0 +1,29 @@
+//
+//  AppDelegate.swift
+//  LockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            print(error.localizedDescription)
+        }
+
+        return true
+    }
+
+}

--- a/JWBestPracticeApps/LockScreenControls/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JWBestPracticeApps/LockScreenControls/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/LockScreenControls/Assets.xcassets/Contents.json
+++ b/JWBestPracticeApps/LockScreenControls/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/LockScreenControls/Base.lproj/LaunchScreen.storyboard
+++ b/JWBestPracticeApps/LockScreenControls/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/JWBestPracticeApps/LockScreenControls/Base.lproj/Main.storyboard
+++ b/JWBestPracticeApps/LockScreenControls/Base.lproj/Main.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Lock Screen View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="LockScreenViewController" customModule="LockScreenControls" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="110"/>
+        </scene>
+    </scenes>
+</document>

--- a/JWBestPracticeApps/LockScreenControls/LockScreenControls-Bridging-Header.h
+++ b/JWBestPracticeApps/LockScreenControls/LockScreenControls-Bridging-Header.h
@@ -1,0 +1,14 @@
+//
+//  LockScreenControls-Bridging-Header.h
+//  LockScreenControls
+//
+//  Created by Michael Salvador on 5/20/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+#ifndef LockScreenControls_Bridging_Header_h
+#define LockScreenControls_Bridging_Header_h
+
+#import <JWPlayer_IOS_SDK/JWPlayerController.h>
+
+#endif /* LockScreenControls_Bridging_Header_h */

--- a/JWBestPracticeApps/LockScreenControls/LockScreenViewController.swift
+++ b/JWBestPracticeApps/LockScreenControls/LockScreenViewController.swift
@@ -1,0 +1,67 @@
+//
+//  LockScreenViewController.swift
+//  LockScreenControls
+//
+//  Created by Michael Salvador on 5/25/20.
+//  Copyright © 2020 Karim Mourra. All rights reserved.
+//
+
+import UIKit
+
+class LockScreenViewController: UIViewController {
+
+    var topPlayer: JWPlayerController!
+    var bottomPlayer: JWPlayerController!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        createTopPlayer()
+        createBottomPlayer()
+
+        // After all players have been instantiated, make sure 'displayLockScreenControls' is set to false for all the players
+        // you don't want to be affected by lock screen controls. Then, set 'displayLockScreenControls' true
+        // for the player you do want the lock screen controls to affect.
+
+        bottomPlayer.displayLockScreenControls = false // Won't be affected by lock screen controls
+        topPlayer.displayLockScreenControls = true // Will be affected by lock screen controls
+
+        // Note: - If a third player is instantiated, it will take over the current lock screen controls,
+        // because 'displayLockScreenControls' defaults to true.
+    }
+
+    func createTopPlayer() {
+        let videoURL = "http://playertest.longtailvideo.com/adaptive/oceans/oceans.m3u8"
+        let posterImageURL = "http://d3el35u4qe4frz.cloudfront.net/bkaovAYt-480.jpg"
+        let config = JWConfig.init(contentUrl: videoURL)
+        config.image = posterImageURL
+        config.title = "Top Player"
+        config.autostart = true
+        config.size = CGSize(width: self.view.frame.size.width, height: self.view.frame.height/2)
+        self.topPlayer = JWPlayerController(config: config)
+        if let playerView = self.topPlayer.view {
+            self.view.addSubview(playerView)
+            let midX = self.view.frame.midX
+            let midY = self.view.frame.midY
+            playerView.center = CGPoint(x: midX, y: midY - (config.size.height/2))
+        }
+    }
+
+    func createBottomPlayer() {
+        let videoURL = "https://playertest.longtailvideo.com/adaptive/bipbop/bipbopall.m3u8"
+        let posterImageURL = "http://d3el35u4qe4frz.cloudfront.net/3XnJSIm4-480.jpg"
+        let config = JWConfig.init(contentUrl: videoURL)
+        config.image = posterImageURL
+        config.title = "Bottom Player"
+        config.autostart = true
+        config.size = CGSize(width: self.view.frame.size.width, height: self.view.frame.size.height/2)
+        self.bottomPlayer = JWPlayerController(config: config)
+        if let playerView = self.bottomPlayer.view {
+            self.view.addSubview(playerView)
+            let midX = self.view.frame.midX
+            let midY = self.view.frame.midY
+            playerView.center = CGPoint(x: midX, y: midY + (config.size.height/2))
+        }
+    }
+}
+

--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -4,7 +4,7 @@
 # use_frameworks!
 
 def common_JW
-    pod 'JWPlayer-SDK', '~> 3.12.0'
+    pod 'JWPlayer-SDK', '~> 3.14.2'
 end
 
 def common_Cast
@@ -52,6 +52,18 @@ target 'Casting' do
   common_JW
   common_Cast
   
+end
+
+target 'LockScreenControls' do
+
+  common_JW
+
+end
+
+target 'JWLockScreenControls' do
+
+  common_JW
+
 end
 
 target 'JWAirPlay' do


### PR DESCRIPTION
This PR adds an Obj-C and Swift target to showcase how to control which player is controlled by the lock screen through the 'displayLockScreenControls' property.