### PR TITLE
[SDK-9735] Handle custom controls visibility based on the setup events

### DIFF
--- a/JWBestPracticeApps/AdvancedPlayer/AdvancedPlayer/ViewController.swift
+++ b/JWBestPracticeApps/AdvancedPlayer/AdvancedPlayer/ViewController.swift
@@ -48,6 +48,7 @@ class ViewController: JWPlayerViewController,
         customControls = UINib(nibName: "CustomControls", bundle: .main).instantiate(withOwner: nil, options: nil).first as? CustomControls
         customControls.translatesAutoresizingMaskIntoConstraints = false
         customControls.delegate = self
+        customControls.isHidden = true
         addCustomControls(toView: view)
 
         // Set up the player.
@@ -266,6 +267,29 @@ class ViewController: JWPlayerViewController,
             let timeRemaining = Int(ceil(self!.skipOffset! - time.position))
             self?.customControls.skipButton.setTitle("Skip Ad in \(timeRemaining)", for: .normal)
         }
+    }
+
+    // MARK: - Observe player setup events
+
+    override func jwplayerIsReady(_ player: JWPlayer) {
+        super.jwplayerIsReady(player)
+
+        // Show the custom controls up when the player is fully initialized.
+        customControls.isHidden = false
+    }
+
+    override func jwplayer(_ player: JWPlayer, failedWithSetupError code: UInt, message: String) {
+        super.jwplayer(player, failedWithSetupError: code, message: message)
+        
+        // Hide the custom controls when the player encounters an error during setup and initialization.
+        customControls.isHidden = true
+    }
+
+    override func jwplayer(_ player: JWPlayer, failedWithError code: UInt, message: String) {
+        super.jwplayer(player, failedWithError: code, message: message)
+
+        // Hide the custom controls when the player encounters an error with playback.
+        customControls.isHidden = true
     }
 
     // MARK: - JWPlayerViewControllerDelegate


### PR DESCRIPTION
* Show custom controls when the player is set up successfully.
* Hides custom controls when the player setup fails.
