### PR TITLE
[SDK-10499] Resume playback after entering fullscreen mode

### DIFF
--- a/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
+++ b/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
@@ -75,10 +75,16 @@ class PlayerViewController: ViewController {
         fullScreenViewController = FullScreenPlayerViewController()
         fullScreenViewController!.modalPresentationStyle = .fullScreen
         
+        let playerStateBeforeFullscreen = player.getState()
+        
         // Assign the full screen view controller as the new controller
         // so the video is put into its view hierarchy, and present it.
         viewManager.setController(fullScreenViewController!)
-        present(fullScreenViewController!, animated: true)
+        present(fullScreenViewController!, animated: true) { [weak self] in
+            if playerStateBeforeFullscreen == .playing {
+                self?.player.play()
+            }
+        }
     }
     
     /// When called, the video returns to normal non-full screen size.

--- a/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
+++ b/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
@@ -81,6 +81,7 @@ class PlayerViewController: ViewController {
         // so the video is put into its view hierarchy, and present it.
         viewManager.setController(fullScreenViewController!)
         present(fullScreenViewController!, animated: true) { [weak self] in
+            // Resume playback if the player was playing before entering fullscreen
             if playerStateBeforeFullscreen == .playing {
                 self?.player.play()
             }


### PR DESCRIPTION
The purpose of this PR is to resume playback after entering fullscreen mode.

The AVPlayer seems to automatically paused when it's moved in the view hierarchy. We account for this in our UI code by checking the state of the player before it enters fullscreen, and resuming playback after entering fullscreen if it was playing. I implement something similar here. 