### PR TITLE
[SDK-10483] Add Offline DRM BPA

### DIFF
--- a/JWBestPracticeApps/JWBestPracticeApps-4x.xcworkspace/contents.xcworkspacedata
+++ b/JWBestPracticeApps/JWBestPracticeApps-4x.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "container:"
       name = "JWPlayerKit">
       <FileRef
+         location = "group:Offline DRM/Offline DRM.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:BasicPlayer/BasicPlayer.xcodeproj">
       </FileRef>
       <FileRef
@@ -33,6 +36,9 @@
       </FileRef>
       <FileRef
          location = "group:JWPlayer Ads/JWPlayer Ads.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Offline DRM/Offline DRM.xcodeproj">
       </FileRef>
       <FileRef
          location = "group:Recommendations/Recommendations.xcodeproj">

--- a/JWBestPracticeApps/Offline DRM/Offline DRM.xcodeproj/project.pbxproj
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM.xcodeproj/project.pbxproj
@@ -1,0 +1,436 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D3B9B5F2293A76A600FC4078 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B9B5F1293A76A600FC4078 /* AppDelegate.swift */; };
+		D3B9B5F6293A76A600FC4078 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B9B5F5293A76A600FC4078 /* ViewController.swift */; };
+		D3B9B5F9293A76A600FC4078 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3B9B5F7293A76A600FC4078 /* Main.storyboard */; };
+		D3B9B5FB293A76A800FC4078 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3B9B5FA293A76A800FC4078 /* Assets.xcassets */; };
+		D3B9B5FE293A76A800FC4078 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3B9B5FC293A76A800FC4078 /* LaunchScreen.storyboard */; };
+		D3B9B606293A76BF00FC4078 /* DRMKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B9B605293A76BF00FC4078 /* DRMKeyManager.swift */; };
+		D3B9B60C293A7EBE00FC4078 /* DRMKeyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B9B60B293A7EBE00FC4078 /* DRMKeyDataSource.swift */; };
+		D3F2BA48293E8037004DC540 /* StudioDRMPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F2BA47293E8037004DC540 /* StudioDRMPlaylist.swift */; };
+		D3F2BA4A293EDE3D004DC540 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = D3F2BA49293EDE3D004DC540 /* README.md */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D3B9B60A293A78BB00FC4078 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D3B9B609293A78BB00FC4078 /* JWPlayerKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		D3B9B5EE293A76A600FC4078 /* Offline DRM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Offline DRM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3B9B5F1293A76A600FC4078 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D3B9B5F5293A76A600FC4078 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		D3B9B5F8293A76A600FC4078 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D3B9B5FA293A76A800FC4078 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D3B9B5FD293A76A800FC4078 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D3B9B5FF293A76A800FC4078 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D3B9B605293A76BF00FC4078 /* DRMKeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMKeyManager.swift; sourceTree = "<group>"; };
+		D3B9B60B293A7EBE00FC4078 /* DRMKeyDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRMKeyDataSource.swift; sourceTree = "<group>"; };
+		D3F2BA47293E8037004DC540 /* StudioDRMPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudioDRMPlaylist.swift; sourceTree = "<group>"; };
+		D3F2BA49293EDE3D004DC540 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D3B9B5EB293A76A600FC4078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		25A5761554641BE881BE7456 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0BC56C50AB9FB309DB1EADA2 /* Pods_Offline_DRM.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D3B9B5E5293A76A600FC4078 = {
+			isa = PBXGroup;
+			children = (
+				D3F2BA49293EDE3D004DC540 /* README.md */,
+				D3B9B5F0293A76A600FC4078 /* Offline DRM */,
+				D3B9B5EF293A76A600FC4078 /* Products */,
+				E14A1D5DEC2B2A26E1690349 /* Pods */,
+				25A5761554641BE881BE7456 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		D3B9B5EF293A76A600FC4078 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D3B9B5EE293A76A600FC4078 /* Offline DRM.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D3B9B5F0293A76A600FC4078 /* Offline DRM */ = {
+			isa = PBXGroup;
+			children = (
+				D3B9B5F1293A76A600FC4078 /* AppDelegate.swift */,
+				D3B9B5F5293A76A600FC4078 /* ViewController.swift */,
+				D3B9B60B293A7EBE00FC4078 /* DRMKeyDataSource.swift */,
+				D3B9B605293A76BF00FC4078 /* DRMKeyManager.swift */,
+				D3F2BA47293E8037004DC540 /* StudioDRMPlaylist.swift */,
+				D3B9B5F7293A76A600FC4078 /* Main.storyboard */,
+				D3B9B5FA293A76A800FC4078 /* Assets.xcassets */,
+				D3B9B5FC293A76A800FC4078 /* LaunchScreen.storyboard */,
+				D3B9B5FF293A76A800FC4078 /* Info.plist */,
+			);
+			path = "Offline DRM";
+			sourceTree = "<group>";
+		};
+		E14A1D5DEC2B2A26E1690349 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0D5B75D18597A314A2C46D41 /* Pods-Offline DRM.debug.xcconfig */,
+				4D4476C2D5B15633ADBC5AD5 /* Pods-Offline DRM.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D3B9B5ED293A76A600FC4078 /* Offline DRM */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D3B9B602293A76A800FC4078 /* Build configuration list for PBXNativeTarget "Offline DRM" */;
+			buildPhases = (
+				75E73250853CDE589849507A /* [CP] Check Pods Manifest.lock */,
+				D3B9B5EA293A76A600FC4078 /* Sources */,
+				D3B9B5EB293A76A600FC4078 /* Frameworks */,
+				D3B9B5EC293A76A600FC4078 /* Resources */,
+				D3B9B60A293A78BB00FC4078 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Offline DRM";
+			productName = "Offline DRM";
+			productReference = D3B9B5EE293A76A600FC4078 /* Offline DRM.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D3B9B5E6293A76A600FC4078 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					D3B9B5ED293A76A600FC4078 = {
+						CreatedOnToolsVersion = 14.0.1;
+					};
+				};
+			};
+			buildConfigurationList = D3B9B5E9293A76A600FC4078 /* Build configuration list for PBXProject "Offline DRM" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D3B9B5E5293A76A600FC4078;
+			productRefGroup = D3B9B5EF293A76A600FC4078 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D3B9B5ED293A76A600FC4078 /* Offline DRM */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D3B9B5EC293A76A600FC4078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3B9B5FE293A76A800FC4078 /* LaunchScreen.storyboard in Resources */,
+				D3B9B5FB293A76A800FC4078 /* Assets.xcassets in Resources */,
+				D3F2BA4A293EDE3D004DC540 /* README.md in Resources */,
+				D3B9B5F9293A76A600FC4078 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		75E73250853CDE589849507A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Offline DRM-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D3B9B5EA293A76A600FC4078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3B9B60C293A7EBE00FC4078 /* DRMKeyDataSource.swift in Sources */,
+				D3B9B5F6293A76A600FC4078 /* ViewController.swift in Sources */,
+				D3B9B606293A76BF00FC4078 /* DRMKeyManager.swift in Sources */,
+				D3B9B5F2293A76A600FC4078 /* AppDelegate.swift in Sources */,
+				D3F2BA48293E8037004DC540 /* StudioDRMPlaylist.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		D3B9B5F7293A76A600FC4078 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D3B9B5F8293A76A600FC4078 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		D3B9B5FC293A76A800FC4078 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D3B9B5FD293A76A800FC4078 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D3B9B600293A76A800FC4078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D3B9B601293A76A800FC4078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D3B9B603293A76A800FC4078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Offline DRM/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jwplayer.BPA-4-x.Offline-DRM";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D3B9B604293A76A800FC4078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Offline DRM/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jwplayer.BPA-4-x.Offline-DRM";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D3B9B5E9293A76A600FC4078 /* Build configuration list for PBXProject "Offline DRM" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D3B9B600293A76A800FC4078 /* Debug */,
+				D3B9B601293A76A800FC4078 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D3B9B602293A76A800FC4078 /* Build configuration list for PBXNativeTarget "Offline DRM" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D3B9B603293A76A800FC4078 /* Debug */,
+				D3B9B604293A76A800FC4078 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D3B9B5E6293A76A600FC4078 /* Project object */;
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/AppDelegate.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/AppDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  AppDelegate.swift
+//  Offline DRM
+//
+//  Created by David Perez on 02/12/22.
+//
+
+import UIKit
+import JWPlayerKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        JWPlayerKitLicense.setLicenseKey(<#T##String#>)
+        return true
+    }
+}
+

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/Contents.json
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Base.lproj/LaunchScreen.storyboard
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Base.lproj/Main.storyboard
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Base.lproj/Main.storyboard
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Offline_DRM" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S0B-HC-W19">
+                                <rect key="frame" x="0.0" y="47.000000000000014" width="390" height="219.33333333333337"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="S0B-HC-W19" secondAttribute="height" multiplier="16:9" id="D3J-2e-PCi"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="yCg-bI-Y0n" kind="embed" id="mzU-YI-fft"/>
+                                </connections>
+                            </containerView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PrB-WZ-eCA" userLabel="download">
+                                <rect key="frame" x="270" y="286.33333333333331" width="100" height="35"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="tinted" title="Download"/>
+                                <connections>
+                                    <action selector="downloadStream:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1bd-7T-s2D"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z7G-BE-cQQ">
+                                <rect key="frame" x="20" y="286.33333333333331" width="0.0" height="0.0"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="S0B-HC-W19" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="0h6-A4-CxQ"/>
+                            <constraint firstItem="S0B-HC-W19" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="6PL-oF-5oJ"/>
+                            <constraint firstItem="PrB-WZ-eCA" firstAttribute="top" secondItem="S0B-HC-W19" secondAttribute="bottom" constant="20" id="Go7-l8-O8U"/>
+                            <constraint firstItem="z7G-BE-cQQ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="c63-QH-qzZ"/>
+                            <constraint firstItem="PrB-WZ-eCA" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" constant="-20" id="f1n-Pb-kxn"/>
+                            <constraint firstItem="S0B-HC-W19" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="u5R-7X-u4N"/>
+                            <constraint firstItem="z7G-BE-cQQ" firstAttribute="top" secondItem="S0B-HC-W19" secondAttribute="bottom" constant="20" id="wkL-F7-0LB"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="stateLabel" destination="z7G-BE-cQQ" id="320-qt-rfM"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="130.76923076923077" y="-55.45023696682464"/>
+        </scene>
+        <!--Player View Controller-->
+        <scene sceneID="Nfr-iT-XuH">
+            <objects>
+                <viewController id="yCg-bI-Y0n" customClass="JWPlayerViewController" customModule="JWPlayerKit" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="0SW-Sx-Jxh">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="219"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="pZ9-FA-t3l"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qO0-YD-Mrg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="820" y="-106"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/DRMKeyDataSource.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/DRMKeyDataSource.swift
@@ -1,0 +1,68 @@
+//
+//  DRMKeyDataSource.swift
+//  Offline DRM
+//
+//  Created by David Perez on 02/12/22.
+//
+
+import JWPlayerKit
+ /**
+  This manages the requests needed for online content keys.
+  This will also be required during the initial creation of offline keys, since we need the certificate and playback context from your key server module.
+  */
+class DRMKeyDataSource: JWDRMContentKeyDataSource {
+    var certificateURLStr: String? = nil
+    var processSPCURLStr: String? = nil
+    
+    /**
+     When called, this delegate method requests the identifier for the protected content to be passed through the delegate method's completion block.
+     */
+    func contentIdentifierForURL(_ url: URL, completionHandler handler: @escaping (Data?) -> Void) {
+        let data = url.host?.data(using: .utf8)
+        handler(data)
+    }
+
+
+    /**
+     When called, this delegate method requests an Application Certificate binary which must be passed through the completion block.
+     - note: The Application Certificate must be encoded with the X.509 standard with distinguished encoding rules (DER). It is obtained when registering an FPS playback app with Apple, by supplying an X.509 Certificate Signing Request linked to your private key.
+     */
+    func appIdentifierForURL(_ url: URL, completionHandler handler: @escaping (Data?) -> Void) {
+        guard let certificateURLStr = certificateURLStr, let certificateURL = URL(string: certificateURLStr) else {
+            return
+        }
+        let request = URLRequest(url: certificateURL)
+        let task = URLSession.shared.dataTask(with: request) { (data, response, err) in
+            if let err = err {
+                print(err.localizedDescription)
+            }
+            handler(data)
+        }
+        task.resume()
+    }
+
+    /**
+     When the key request is ready, this delegate method provides the key request data (SPC - Server Playback Context message) needed to retrieve the Content Key Context (CKC) message from your key server. The CKC message must be returned via the completion block under the response parameter.
+
+     After your app sends the request to the server, the FPS code on the server sends the required key to the app. This key is wrapped in an encrypted message. Your app provides the encrypted message to the JWPlayerKit. The JWPlayerKit unwraps the message and decrypts the stream to enable playback on an iOS device.
+
+     - note: For resources that may expire, specify a renewal date and the content-type in the completion block.
+     */
+    func contentKeyWithSPCData(_ spcData: Data, completionHandler handler: @escaping (Data?, Date?, String?) -> Void) {
+        guard let processSPCURLStr = processSPCURLStr, let processSPCURL = URL(string: processSPCURLStr) else {
+            return
+        }
+        var request = URLRequest(url: processSPCURL)
+        request.httpMethod = "POST"
+        request.addValue("application/octet-stream", forHTTPHeaderField: "Content-type")
+        request.httpBody = spcData
+
+        let task = URLSession.shared.dataTask(with: request) { (data, response, err) in
+            if let err = err {
+                print(err.localizedDescription)
+            }
+            handler(data, nil, "application/octet-stream")
+        }
+        task.resume()
+    }
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/DRMKeyManager.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/DRMKeyManager.swift
@@ -1,0 +1,75 @@
+//
+//  DRMKeyManager.swift
+//  Offline DRM
+//
+//  Created by David Perez on 02/12/22.
+//
+
+import JWPlayerKit
+/**
+ This class will handle keys stored in your device.
+ This will gets notified when the `JWDRMContentLoader` requests to write, delete, check if keys exist, get the URL for the keys in memory, and report errors while handling these keys.
+ */
+class DRMKeyManager: JWDRMContentKeyManager {
+    
+    let keyDirectory: URL
+    
+    init() {
+        let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            
+        guard let contentKeyDirectory =  documentDirectory?.appendingPathComponent(".key/", isDirectory: true) else {
+            fatalError("This device does not have a valid document directory")
+        }
+        
+        if !FileManager.default.fileExists(atPath: contentKeyDirectory.path, isDirectory: nil) {
+            do {
+                try FileManager.default.createDirectory(at: contentKeyDirectory,
+                                                        withIntermediateDirectories: false,
+                                                        attributes: nil)
+            } catch {
+                fatalError("Unable to create directory for content keys at path: \(contentKeyDirectory.path)")
+            }
+        }
+        keyDirectory = contentKeyDirectory
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, writePersistableContentKey contentKey: Data, contentKeyIdentifier: String) {
+        do {
+           try contentKey.write(to: keyDirectory.appendingPathExtension(contentKeyIdentifier))
+        } catch {
+            print("Error writing keys to directory:", error.localizedDescription)
+        }
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, didWritePersistableContentKey contentKeyIdentifier: String) {
+        // We can updated on client side if we were waiting for the keys to be saved on memory.
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, deletePersistableContentKey contentKeyIdentifier: String) {
+        do {
+            try FileManager.default.removeItem(at: keyDirectory.appendingPathExtension(contentKeyIdentifier))
+
+        } catch {
+            print("Error deleting keys from directory:", error.localizedDescription)
+        }
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, contentKeyTypeFor contentKeyIdentifier: String) -> JWPlayerKit.JWContentKeyType {
+        // We return the type of content, if this is intended to be non persistable then return .nonPersistable to use online DRM.
+        return .persistable
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, contentKeyExistsOnDisk contentKeyIdentifier: String) -> Bool {
+        // We check the device for the keys at the especified path.
+        return FileManager.default.fileExists(atPath: keyDirectory.appendingPathExtension(contentKeyIdentifier).relativePath)
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, urlForPersistableContentKey contentKeyIdentifier: String) -> URL {
+        // We return the url for the keys. This gets called after we have checked that they are on system.
+        return keyDirectory.appendingPathExtension(contentKeyIdentifier)
+    }
+    
+    func contentLoader(_ contentLoader: JWPlayerKit.JWDRMContentLoader, failedWithError error: JWPlayerKit.JWError) {
+        print("Encountered an error from the JWDRMContentLoader: ", error.localizedDescription)
+    }
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/Info.plist
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/StudioDRMPlaylist.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/StudioDRMPlaylist.swift
@@ -1,0 +1,80 @@
+//
+//  StudioDRMPlaylist.swift
+//  Offline DRM
+//
+//  Created by David Perez on 05/12/22.
+//
+
+import Foundation
+
+// MARK: - DRMPlaylist
+// Refer to https://docs.jwplayer.com/players/docs/ios-apply-studio-drm-with-jw-platform#implementation for example Studio DRM implementation for iOS.
+struct DRMPlaylist: Codable {
+    let title, kind: String
+    let playlist: [Playlist]
+    let feedInstanceID: String
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case kind, playlist
+        case feedInstanceID = "feed_instance_id"
+    }
+}
+
+// MARK: - Playlist
+struct Playlist: Codable {
+    let title, mediaid: String
+    let link: String
+    let image: String
+    let images: [Image]
+    let duration, pubdate: Int
+    let playlistDescription: String
+    let sources: [Source]
+    let tracks: [Track]
+
+    enum CodingKeys: String, CodingKey {
+        case title, mediaid, link, image, images, duration, pubdate
+        case playlistDescription = "description"
+        case sources, tracks
+    }
+}
+
+// MARK: - Image
+struct Image: Codable {
+    let src: String
+    let width: Int
+    let type: String
+}
+
+// MARK: - Source
+struct Source: Codable {
+    let drm: DRM
+    let file: String
+    let type: String
+}
+
+// MARK: - DRM
+struct DRM: Codable {
+    let fairplay: Fairplay?
+}
+
+// MARK: - Fairplay
+struct Fairplay: Codable {
+    let processSpcURL, certificateURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case processSpcURL = "processSpcUrl"
+        case certificateURL = "certificateUrl"
+    }
+}
+
+// MARK: - Playready
+struct Playready: Codable {
+    let url: String
+}
+
+// MARK: - Track
+struct Track: Codable {
+    let file: String
+    let kind: String
+}

--- a/JWBestPracticeApps/Offline DRM/Offline DRM/ViewController.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/ViewController.swift
@@ -1,0 +1,206 @@
+//
+//  ViewController.swift
+//  Offline DRM
+//
+//  Created by David Perez on 02/12/22.
+//
+
+import JWPlayerKit
+import AVFoundation
+
+class ViewController: UIViewController, AVAssetDownloadDelegate {
+    // MARK: - IBOutlet
+    /// Presents the current state of the offline media.
+    @IBOutlet private weak var stateLabel: UILabel?
+    
+    // MARK: - Properties
+   
+    /// The key for requesting the data from UserDefaults
+    private let savedDataKey = "localVideoFile"
+    // MARK: - DRM management properties
+    /// The content key loader.
+    private var contentLoader: JWDRMContentLoader?
+    private let keyManager: JWDRMContentKeyManager = DRMKeyManager()
+    private let keyDataSource: DRMKeyDataSource = DRMKeyDataSource()
+    // MARK: - Playlist properties
+    // The playlist signed URL for DRM protected content.
+    private let playlistURL = "<#T##String#>"
+    /// The video file from the signed URL, this gets set after parsing the playlist.
+    private var videoFile = ""
+    /// The location in memory for the local video, this gets set when downloading the asset. Not directly used.
+    private var localVideoFile: URL? = nil
+    /// The local video URL, this gets set from memory if the video is saved and used as the locator for memory videos. Bookmarked data allows us to access the video file in memory since it is stored in a secure location.
+    private var localURL: URL? {
+        let persistedData = UserDefaults.standard.data(forKey: savedDataKey)
+        guard let boomarkData = persistedData else {
+            return nil
+        }
+        var dataStaleStatus = false
+        let url = try? URL(resolvingBookmarkData: boomarkData,
+                           bookmarkDataIsStale: &dataStaleStatus)
+        return dataStaleStatus ? nil : url
+    }
+    /// The player interface, this is from the JWPlayerViewController embedded in a container view.a
+    private var player: JWPlayerProtocol? = nil
+    
+    /// The AVAssetDownloadURLSession to use for managing AVAssetDownloadTasks.
+    private var assetDownloadURLSession: AVAssetDownloadURLSession!
+    /// The delegate queue for the AVAssetDownloadURLSession
+    private let delegateQueue = OperationQueue()
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        /// The keys can be pre-loaded by calling load on the content loader.
+        let url = URL(string: playlistURL)!
+        contentLoader = JWDRMContentLoader(dataSource: keyDataSource, keyManager: keyManager)
+        self.contentLoader?.load(playlist: url)
+        
+        // We construct a playlist either from the remote asset or a local asset if it is saved.
+        var config: JWPlayerConfiguration!
+        
+        if let localURL = localURL {
+            config = self.getPlaylist(local: localURL)
+            // Updates the UI to reflect that the asset is already downloaded.
+            stateLabel?.text = "Saved"
+        } else {
+            config = self.getPlaylist(remote: url)
+        }
+        // We set the content loader to the player.
+        self.player?.contentLoader = self.contentLoader
+        // We configure the player.
+        self.player?.configurePlayer(with: config)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Create the configuration for the AVAssetDownloadURLSession.
+        let backgroundConfiguration = URLSessionConfiguration.background(withIdentifier: "AAPL-Identifier")
+        assetDownloadURLSession = AVAssetDownloadURLSession(configuration: backgroundConfiguration,
+                                                            assetDownloadDelegate: self, delegateQueue: delegateQueue)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let playerViewController = segue.destination as? JWPlayerViewController else {
+            return
+        }
+        // Set this controller's player reference to the embedded JWPlayerViewController's.
+        self.player = playerViewController.player
+    }
+    
+    func getPlaylist(remote url: URL) -> JWPlayerConfiguration? {
+        let sem = DispatchSemaphore(value: 0)
+        let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, err in
+            defer {
+                sem.signal()
+            }
+            guard let self = self else {
+                return
+            }
+            if let error = err {
+                fatalError("Playlist URL request failed: \(error.localizedDescription)")
+            }
+            do {
+                let playlist = try JSONDecoder().decode(DRMPlaylist.self, from: data!)
+                guard let source = playlist.playlist.first?.sources.first(where: { $0.type == "application/vnd.apple.mpegurl" }) else {
+                    return
+                }
+                // After parsing the playlist, set the current video file
+                self.videoFile = source.file
+                // Set the certificate URL we will need for for the JWDRMKeyDataSource
+                self.keyDataSource.certificateURLStr = source.drm.fairplay?.certificateURL
+                // Set the process SPC URL we will need for for the JWDRMKeyDataSource
+                self.keyDataSource.processSPCURLStr = source.drm.fairplay?.processSpcURL
+            } catch {
+                print("Error decoding data from playlist URL", error.localizedDescription)
+            }
+        }
+        task.resume()
+        sem.wait()
+        // Create a configuration from the video file.
+        let fileURL = URL(string: videoFile)!
+        var config: JWPlayerConfiguration? = nil
+        do {
+            let playerItem = try JWPlayerItemBuilder().file(fileURL).build()
+            config = try JWPlayerConfigurationBuilder()
+                .playlist(items: [playerItem]).build()
+        } catch {
+            // Handle any error thrown during the configuration build
+            print("Error encountered while building the configuration:", error.localizedDescription)
+        }
+       
+        return config
+    }
+    
+    func getPlaylist(local url: URL) -> JWPlayerConfiguration? {
+        var config: JWPlayerConfiguration? = nil
+        do {
+            let playerItem = try JWPlayerItemBuilder().file(url).build()
+            config = try JWPlayerConfigurationBuilder()
+                .playlist(items: [playerItem]).build()
+        } catch {
+            // Handle any error thrown during the configuration build
+            print("Error encountered while building the configuration:", error.localizedDescription)
+        }
+
+        return config
+    }
+    
+    /// Triggers the initial AVAssetDownloadTask for a given Asset.
+    func downloadStream(for asset: AVURLAsset) {
+        // Get the default media selections for the asset's media selection groups.
+        let preferredMediaSelection = asset.preferredMediaSelection
+        
+        /*
+         Creates and initializes an AVAggregateAssetDownloadTask to download multiple AVMediaSelections
+         on an AVURLAsset.
+         
+         For the initial download, we ask the URLSession for an AVAssetDownloadTask with a minimum bitrate
+         corresponding with one of the lower bitrate variants in the asset.
+         */
+        guard let task =
+                assetDownloadURLSession.aggregateAssetDownloadTask(with: asset,
+                                                                   mediaSelections: [preferredMediaSelection],
+                                                                   assetTitle: asset.description,
+                                                                   assetArtworkData: nil,
+                                                                   options:
+                                                                    [AVAssetDownloadTaskMinimumRequiredMediaBitrateKey: 265_000]) else {
+            return
+        }
+        
+        task.resume()
+    }
+    
+    func urlSession(_ session: URLSession, aggregateAssetDownloadTask: AVAggregateAssetDownloadTask, didCompleteFor mediaSelection: AVMediaSelection) {
+        DispatchQueue.main.async { [weak self] in
+            self?.stateLabel?.text = "Saved"
+        }
+        do {
+            let data = try localVideoFile?.bookmarkData()
+            UserDefaults.standard.set(data, forKey: savedDataKey)
+        } catch {
+            print("Error saving bookmark data")
+        }
+        
+    }
+    
+    func urlSession(_ session: URLSession, aggregateAssetDownloadTask: AVAggregateAssetDownloadTask, willDownloadTo location: URL) {
+        localVideoFile = location
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            print("Error while downloading the asset: ", error.localizedDescription)
+        }
+    }
+    
+    @IBAction func downloadStream(_ sender: UIButton) {
+        guard let video = URL(string: videoFile) else {
+            return
+        }
+        // If we have a video file, start downloading the asset.
+        let asset = AVURLAsset(url: video)
+        downloadStream(for: asset)
+        stateLabel?.text = "Downloading"
+    }
+}
+

--- a/JWBestPracticeApps/Offline DRM/README.md
+++ b/JWBestPracticeApps/Offline DRM/README.md
@@ -1,0 +1,34 @@
+
+## Offline DRM - Best Practices App
+
+  
+
+The DRM Fairplay project illustrates how to use our DRM implementation to play a FairPlay encrypted streams. The stream should be a (signed URL)[https://docs.jwplayer.com/platform/reference/protect-your-content-with-signed-urls] that you generate for DRM protected content from JW Player StudioDRM.
+
+Important: you need a Fairplay package from Apple to enable Fairplay for your content, more information (here)[https://docs.jwplayer.com/players/docs/ios-apply-studio-drm-with-jw-platform#enabling-apple-fairplay-streaming].
+
+For `JWPlayerKit` to request your content keys we can do it in two ways:
+
+* Requesting them directly through an instance of `JWDRMContentLoader` by loading the asset, calling `JWDRMContentLoader.load` and using the `JWDRMContentKeyManager` to listen to updates from the content loader.
+
+* Initializing an instance of a `JWDRMContentLoader` and setting it as the player's `contentLoader`. You will still need to listen to updates from the content loader in your `JWDRMContentKeyManager`.
+
+The updates that are received from the `JWDRMContentLoader` in your `JWDRMContentKeyManager` are:
+
+* To write the keys.
+
+* To notify they have been written.
+
+* To get the key type, if they will be persistable or not.
+
+* To delete the keys.
+
+* To check if the keys exist in memory.
+
+* To get the URL for the keys.
+
+* To report that an error has been encountered.
+
+On this BPA, we also add a snippet to download the DRM HLS stream so that you can test that the keys are working offline.
+
+> ****Note:**** FairPlay streams ****cannot**** be played on the simulator; you will need to run this project on a device.

--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -89,6 +89,11 @@ target 'Captions' do
   common_JWPlayer
 end
 
+target 'Offline DRM' do
+  project 'Offline DRM/Offline DRM'
+  common_JWPlayer
+end
+
 ####################################
 #### JWPlayerTVKit tvOS targets ####
 ####################################


### PR DESCRIPTION

### What does this PR do?

* This adds an offline DRM best practice app
* This adds a simple key manager to handle content key memory
* This adds a way to download the HLS asset in memory to persist and play offline

### Why was this PR needed?
We need to add a best practice implementation of Offline DRM

### What should reviewers double check?
That this is simple, documented and easy to use as modular standalone `JWDRMContentLoader` or as part of a player.

### What issues does this fix?
[SDK-10483]