### PR TITLE
[SDK-9523] Set PiP button default to disabled

### DIFF
--- a/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
+++ b/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
@@ -90,17 +90,10 @@ class PlayerViewController: ViewController {
     
     /// When called, the video returns to normal non-full screen size.
     func exitFullScreen() {
-        let playerStateBeforeFullscreen = player.getState()
         // Set this view controller as the new controller, and dismiss the
         // full screen view controller.
         viewManager.setController(self)
-        fullScreenViewController?.dismiss(animated: true) { [weak self] in
-            // Resume playback if the player was playing before entering fullscreen
-            if playerStateBeforeFullscreen == .playing {
-                self?.player.play()
-            }
-        }
-        
+        fullScreenViewController?.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
+++ b/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
@@ -90,10 +90,17 @@ class PlayerViewController: ViewController {
     
     /// When called, the video returns to normal non-full screen size.
     func exitFullScreen() {
+        let playerStateBeforeFullscreen = player.getState()
         // Set this view controller as the new controller, and dismiss the
         // full screen view controller.
         viewManager.setController(self)
-        fullScreenViewController?.dismiss(animated: true, completion: nil)
+        fullScreenViewController?.dismiss(animated: true) { [weak self] in
+            // Resume playback if the player was playing before entering fullscreen
+            if playerStateBeforeFullscreen == .playing {
+                self?.player.play()
+            }
+        }
+        
     }
 }
 

--- a/JWBestPracticeApps/Picture in Picture/Picture in Picture/Base.lproj/Main.storyboard
+++ b/JWBestPracticeApps/Picture in Picture/Picture in Picture/Base.lproj/Main.storyboard
@@ -35,7 +35,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Picture in Picture" id="CrZ-V7-9G3">
-                        <barButtonItem key="rightBarButtonItem" title="Item" image="pip" catalog="system" id="ObE-EU-A9R">
+                        <barButtonItem key="rightBarButtonItem" enabled="NO" title="Item" image="pip" catalog="system" id="ObE-EU-A9R">
                             <connections>
                                 <action selector="pipButtonTapped:" destination="BYZ-38-t0r" id="17j-k0-mkV"/>
                             </connections>

--- a/JWBestPracticeApps/Picture in Picture/Picture in Picture/ViewController.swift
+++ b/JWBestPracticeApps/Picture in Picture/Picture in Picture/ViewController.swift
@@ -14,9 +14,13 @@ class ViewController: UIViewController {
     @IBOutlet weak var pipButton: UIBarButtonItem!
     weak var playerVC: JWPlayerViewController?
 
-    private let videoUrlString = "http://playertest.longtailvideo.com/adaptive/bbbfull/bbbfull.m3u8"
+    private let videoUrlString = "https://playertest.longtailvideo.com/adaptive/bbbfull/bbbfull.m3u8"
     private let posterUrlString = "https://d3el35u4qe4frz.cloudfront.net/bkaovAYt-480.jpg"
     private var pipPossibleObservation: NSKeyValueObservation?
+
+    deinit {
+        pipPossibleObservation = nil
+    }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         // If we are loading the PlayerViewController, we create a config and hand it off.
@@ -35,7 +39,7 @@ class ViewController: UIViewController {
 
                 // Second, create a player config with the created JWPlayerItem and JWAdvertisingConfig
                 let config = try JWPlayerConfigurationBuilder()
-                    .playlist([playerItem])
+                    .playlist(items: [playerItem])
                     .autostart(true)
                     .build()
 


### PR DESCRIPTION
### What does this Pull Request do?
* Since the PiPController is not created if it is not PiP compatible it cannot start listening to PiP availability in the context. If we set to disabled as the default it will only change if PiP is possible.
![Screen Shot 2023-02-07 at 17 33 05](https://user-images.githubusercontent.com/32963483/217391376-a12177d0-8d16-495f-aa73-58586e917cf9.png)

### Why is this Pull Request needed?
PiP button appears as enabled on non supported OS
### Are there any points in the code the reviewer needs to double check?
None
### Are there any Pull Requests open in other repos which need to be merged with this?
None
#### Addresses Issue(s):
[SDK-9523]
iOS-####

#### Commands

`test this please` - re-run the PR builder

`Test {tag) tag, please` - run the tags specified against the JWPlayerKitTestApp

`Test (scenarioLocation) scenario, please` - run the scenario at the scenario location against the JWPlayerKitTestApp


[SDK-9523]: https://jwplayer.atlassian.net/browse/SDK-9523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ