### PR TITLE
[SDK-10499] Resume state after exiting fullscreen

### DIFF
--- a/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
+++ b/JWBestPracticeApps/Custom UI/Custom UI/Custom Player/PlayerViewController.swift
@@ -90,10 +90,16 @@ class PlayerViewController: ViewController {
     
     /// When called, the video returns to normal non-full screen size.
     func exitFullScreen() {
+        let playerStateBeforeFullscreen = player.getState()
         // Set this view controller as the new controller, and dismiss the
         // full screen view controller.
         viewManager.setController(self)
-        fullScreenViewController?.dismiss(animated: true, completion: nil)
+        fullScreenViewController?.dismiss(animated: true) { [weak self] in
+            // Resume playback if the player was playing before entering fullscreen
+            if playerStateBeforeFullscreen == .playing {
+                self?.player.play()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### What does this Pull Request do?
* This uses the same logic when going to fullscreen to resume the previous state that was used when the transition ended.
### Why is this Pull Request needed?
Playback pauses after returning from fullscreen if the app was previously backgrounded
### Are there any points in the code the reviewer needs to double check?
None
### Are there any Pull Requests open in other repos which need to be merged with this?
None
#### Addresses Issue(s):
[SDK-10499]
iOS-####

#### Commands

`test this please` - re-run the PR builder

`Test {tag) tag, please` - run the tags specified against the JWPlayerKitTestApp

`Test (scenarioLocation) scenario, please` - run the scenario at the scenario location against the JWPlayerKitTestApp


[SDK-10499]: https://jwplayer.atlassian.net/browse/SDK-10499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ