### PR TITLE
[SDK-10826] Tweaked code to prevent a crash when DRM demo has invalid URL

### DIFF
--- a/JWBestPracticeApps/Offline DRM/Offline DRM/ViewController.swift
+++ b/JWBestPracticeApps/Offline DRM/Offline DRM/ViewController.swift
@@ -55,7 +55,10 @@ class ViewController: UIViewController, AVAssetDownloadDelegate {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         /// The keys can be pre-loaded by calling load on the content loader.
-        let url = URL(string: playlistURL)!
+        guard let url = URL(string: playlistURL) {
+            print("Cannot initialize player because playlistURL is invalid. URL:'\(playlistURL)'")
+            return
+        }
         contentLoader = JWDRMContentLoader(dataSource: keyDataSource, keyManager: keyManager)
         self.contentLoader?.load(playlist: url)
         


### PR DESCRIPTION
Places URL in a guard statement to prevent crashing when someone does not supply a valid URL for the content.