### PR TITLE
[SDK-10858] Fixed audio so it plays for IMA with hardware audio shutoff enabled.

### DIFF
--- a/JWBestPracticeApps/Google IMA Ads/Google IMA Ads/AppDelegate.swift
+++ b/JWBestPracticeApps/Google IMA Ads/Google IMA Ads/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import JWPlayerKit
+import AVFoundation
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -18,6 +19,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Add your JW Player license key.
         // JWPlayerKitLicense.setLicenseKey(<#key: String#>)
+        
+        // Adust the audio session so IMA ads can be heard with the
+        // hardware switch for audio turned off.
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .moviePlayback, options: [])
+            try audioSession.setActive(true)
+        } catch {
+            print("Error setting the AVAudioSession:", error.localizedDescription)
+        }
 
         return true
     }

--- a/JWBestPracticeApps/Google IMA companion ads/Google IMA Companion Ads/AppDelegate.swift
+++ b/JWBestPracticeApps/Google IMA companion ads/Google IMA Companion Ads/AppDelegate.swift
@@ -7,17 +7,26 @@
 
 import UIKit
 import JWPlayerKit
+import AVFoundation
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
         // Add your JW Player license key.
         // JWPlayerKitLicense.setLicenseKey(<#key: String#>)
+        
+        // Adust the audio session so IMA ads can be heard with the
+        // hardware switch for audio turned off.
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .moviePlayback, options: [])
+            try audioSession.setActive(true)
+        } catch {
+            print("Error setting the AVAudioSession:", error.localizedDescription)
+        }
         
         return true
     }


### PR DESCRIPTION
IMA ads were not playing audio on physical devices when the hardware audio shutoff button was in the 'off' position. This PR fixes it so this button does not affect the audio playback of the IMA ads.