### PR TITLE
[SDK-11103] Updates Podfile for precise IMA version

### DIFF
--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -15,7 +15,7 @@ def common_Cast
 end
 
 def common_Google_IMA
-  pod 'GoogleAds-IMA-iOS-SDK', '~> 3.18.4'
+  pod 'GoogleAds-IMA-iOS-SDK', '3.18.4'
 end
 
 target 'AdvancedPlayer' do


### PR DESCRIPTION
pod `'JWPlayerKit', '~> 3.18.4'` will update to 3.18.5, which does not support iOS 12 or 13.

It should be changed to pod `'JWPlayerKit', '3.18.4'` so that version gets installed, no more, no less.