### PR TITLE
[SDK-10338] Updates cast SDK to 4.8.0; implements cast button delegate

### DIFF
--- a/JWBestPracticeApps/Chromecast-GCKUICastButton/ChromeCast-GCKUICastButton/ViewController.swift
+++ b/JWBestPracticeApps/Chromecast-GCKUICastButton/ChromeCast-GCKUICastButton/ViewController.swift
@@ -65,6 +65,7 @@ class ViewController: JWPlayerViewController {
         // We initialize the GCKUICastButton and add to the view, for the user to interact with.
         let castButton = GCKUICastButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
         castButton.tintColor = .white
+        castButton.delegate = self
         // Since this is embedded in a container view, we update the parent's navigation item.
         parent?.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: castButton)
     }
@@ -91,7 +92,7 @@ class ViewController: JWPlayerViewController {
     override func castController(_ controller: JWCastController, disconnectedWithError error: Error?) {
         super.castController(controller, disconnectedWithError: error)
         
-        if let error = error {
+        if let error {
             print("[JWCastDelegate]: Casting disconnected from device with error: \"\(error.localizedDescription)\"")
         }
         else {
@@ -135,7 +136,7 @@ class ViewController: JWPlayerViewController {
     override func castController(_ controller: JWCastController, castingEndedWithError error: Error?) {
         super.castController(controller, castingEndedWithError: error)
         
-        if let error = error {
+        if let error {
             print("[JWCastDelegate]: Casting ended with error: \"\(error.localizedDescription)\"")
         }
         else {
@@ -146,3 +147,25 @@ class ViewController: JWPlayerViewController {
 }
 
 
+// MARK: GCKUICastButtonDelegate
+
+extension ViewController: GCKUICastButtonDelegate {
+    func castButtonDidTap(_ castButton: GCKUICastButton, toPresentDialogFor castState: GCKCastState) {
+        print(#function, "for state: ** \(castState.description) **")
+    }
+
+    func castButtonDidTap(toPresentLocalNetworkAccessPermissionDialog castButton: GCKUICastButton) {
+        print(#function)
+    }
+}
+
+extension GCKCastState: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .noDevicesAvailable: return "noDevicesAvailable"
+        case .notConnected: return "notConnected"
+        case .connecting: return "connecting"
+        case .connected: return "connected"
+        }
+    }
+}

--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -11,7 +11,7 @@ def common_JWPlayer
 end
 
 def common_Cast
-  pod 'google-cast-sdk', '~> 4.5.3'
+  pod 'google-cast-sdk', '~> 4.8.0'
 end
 
 def common_Google_IMA

--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -7,11 +7,11 @@ def common_JWPlayer
   workspace 'JWBestPracticeApps-4x'
   use_frameworks!
   
-  pod 'JWPlayerKit', '~> 4'
+  pod 'JWPlayerKit', '>= 4.17.1'
 end
 
 def common_Cast
-  pod 'google-cast-sdk', '~> 4.8.0'
+  pod 'google-cast-sdk', '4.8.0'
 end
 
 def common_Google_IMA


### PR DESCRIPTION
* No API changes needed for the update to 4.8.0
* Change in Podfile, though note that this does not work (as described in our docs and the ReadMe) and is only a 'POC' pod addition (as expected).
* Added trivial implementation of the new `GCKUICastButtonDelegate`.