### PR TITLE
Locks the app to `.portrait` orientation

### DIFF
--- a/JWBestPracticeApps/FeedTableViewController/FeedTableViewController.xcodeproj/project.pbxproj
+++ b/JWBestPracticeApps/FeedTableViewController/FeedTableViewController.xcodeproj/project.pbxproj
@@ -404,8 +404,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -434,8 +433,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/JWBestPracticeApps/FeedTableViewController/FeedTableViewController/Feed/Playlist.swift
+++ b/JWBestPracticeApps/FeedTableViewController/FeedTableViewController/Feed/Playlist.swift
@@ -10,15 +10,13 @@ import JWPlayerKit
 
 /// A structure that provides a hard-coded 'feed' of `JWPlayerItem`s.
 struct Playlist {
-    /// A hard-coded playlist on the
-    /// * The "BPA Manual, landscape" playlist, id: [d7sk9orq](https://cdn.jwplayer.com/v2/playlists/d7sk9orq)
-    /// * The "BPA Manual, portrait" playlist, id: [V44RvNO4](https://cdn.jwplayer.com/v2/playlists/V44RvNO4)
+    /// A hard-coded playlist on the of assets in portrait resolution, with `playlistId`: [V44RvNO4](https://cdn.jwplayer.com/v2/playlists/V44RvNO4)
     static var bpaManual: [JWPlayerItem] = {
         titledSources
             .compactMap {
                 try? JWPlayerItemBuilder()
                     .title($0)
-                    .file( URL(string: $1)! )
+                    .file(URL(string: $1)!)
                     .build()
             }
     }()


### PR DESCRIPTION
As a 'Tik Tok-esque' scrolling feed, no need for landscape mode, and so it does not account for it (constraints or otherwise).