### PR TITLE
[SDK-11385] Updates Podfile versions for 4.19.0

### DIFF
--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -7,7 +7,7 @@ def common_JWPlayer
   workspace 'JWBestPracticeApps-4x'
   use_frameworks!
   
-  pod 'JWPlayerKit', '>= 4.17.1'
+  pod 'JWPlayerKit', '>= 4.19.0'
 end
 
 def common_Cast
@@ -15,7 +15,7 @@ def common_Cast
 end
 
 def common_Google_IMA
-  pod 'GoogleAds-IMA-iOS-SDK', '3.19.1'
+  pod 'GoogleAds-IMA-iOS-SDK', '3.22.0'
 end
 
 target 'AdvancedPlayer' do


### PR DESCRIPTION
Default min SDK version set to 4.19.0 b/c [Privacy Manifest](https://releases.jwplayer.com/label/43616#:~:text=JWP%20iOS%20SDK%20contains%20a%20privacy%20manifest%20file%20(PrivacyInfo.xcprivacy)%20and%20a%20signature%20for%20the%20SDK.)

[Same reason](https://developers.google.com/interactive-media-ads/docs/sdks/ios/client-side/history?hl=en#:~:text=Adds%20a%20privacy%20manifest%20PrivacyInfo.xcprivacy%20file%20and%20a%20signature%20for%20the%20SDK.) for requiring IMA 3.22.0
