### PR TITLE
[SDK-11386] Updates google-cast-sdk pod version to 4.8.1

### DIFF
--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -11,7 +11,7 @@ def common_JWPlayer
 end
 
 def common_Cast
-  pod 'google-cast-sdk', '4.8.0'
+  pod 'google-cast-sdk', '4.8.1'
 end
 
 def common_Google_IMA


### PR DESCRIPTION
Google Cast SDK 4.8.1 includes the new PrivacyInfo requirement.