### PR TITLE
Bump JWPlayerKit to 4.26.2

### DIFF
--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -7,7 +7,7 @@ def common_JWPlayer
   workspace 'JWBestPracticeApps-4x'
   use_frameworks!
   
-  pod 'JWPlayerKit', '4.26.0'
+  pod 'JWPlayerKit', '4.26.2'
 end
 
 def common_Cast


### PR DESCRIPTION
## Summary

- Bump `JWPlayerKit` Podfile pin from `4.26.0` to `4.26.2`.

## Test plan

- [x] `pod install` resolves cleanly to JWPlayerKit 4.26.2 (validated locally via `:git` against the public spec repo while the CocoaPods CDN index propagates; the published Trunk version is the same artifact, so plain `pod install --repo-update` will work as soon as the CDN's `all_pods_versions_8_8_e.txt` index file lists 4.26.2 — typically within ~1h of the Trunk publish).
- [x] `xcodebuild -scheme BasicPlayer-Swift` builds against 4.26.2: **BUILD SUCCEEDED**.
- [x] `xcodebuild -scheme AdvancedPlayer` builds against 4.26.2: **BUILD SUCCEEDED**.

## Notes

- 4.26.2 is live on the public CocoaPods Trunk as of 2026-05-26 17:20:13 UTC (`pod trunk info JWPlayerKit | grep 4.26.2`).
- The cocoapods deploy Jenkins job (build #29) reported FAILURE due to a transient CocoaPods Trunk `An internal server error occurred` AFTER Trunk had already accepted the spec — same family of transient as build #27 for 4.26.1. Verified via `pod trunk info` that 4.26.2 is published.