### PR TITLE
Bump JWPlayerKit to 4.27.0

### DIFF
--- a/JWBestPracticeApps/Podfile
+++ b/JWBestPracticeApps/Podfile
@@ -7,7 +7,7 @@ def common_JWPlayer
   workspace 'JWBestPracticeApps-4x'
   use_frameworks!
   
-  pod 'JWPlayerKit', '4.26.2'
+  pod 'JWPlayerKit', '4.27.0'
 end
 
 def common_Cast
@@ -16,7 +16,7 @@ def common_Cast
 end
 
 def common_Google_IMA
-  pod 'GoogleAds-IMA-iOS-SDK', '3.22.1'
+  pod 'GoogleAds-IMA-iOS-SDK', '3.32.0'
 end
 
 target 'AdvancedPlayer' do


### PR DESCRIPTION
Bumps the best-practice apps to JWPlayerKit **4.27.0**.

### Changes
- `JWPlayerKit` 4.26.2 → **4.27.0**
- `GoogleAds-IMA-iOS-SDK` 3.22.1 → **3.32.0**

The IMA bump travels with the SDK bump: 4.27.0 raises its IMA floor to 3.28.10, and below that floor the DAI integration is silently disabled. Pinning 3.32.0 matches the pin the iOS SDK itself builds and tests against.

### Verification
Built against the staging 4.27.0 artifacts (Xcode 26.5, iPhone 17 simulator) — 8/8 CocoaPods targets compile:

AdvancedPlayer · BasicPlayer-Swift · BasicPlayer-ObjC · Google IMA Ads · Google DAI Ads · Captions · ChromeCast · Picture in Picture

Runtime check: AdvancedPlayer launches, licenses, and renders video with no errors. The same 4.27.0 binary was also verified through Swift Package Manager (AdvancedPlayer, Captions, Picture in Picture) — SPM checksum matches the published zip.

### Merge gate
Do not merge until **4.27.0 is live on public CocoaPods Trunk**. As of this PR, Trunk tops out at 4.26.2 and the prod cocoapods deploy has not run yet — `pod install` will fail to resolve 4.27.0 until it does.